### PR TITLE
Updated Storer Interface to expect Reader

### DIFF
--- a/storer/storer.go
+++ b/storer/storer.go
@@ -1,10 +1,10 @@
 package storer
 
-import "encoding/json"
+import "io"
 
 // Storer writes data collected from Collector to some form
 // of persistent storage
 type Storer interface {
 	initialize() error
-	saveEntries(json json.Encoder, tag string) error
+	saveEntries(json io.Reader, tag string) error
 }


### PR DESCRIPTION
If we expect the Collector interface to produce readers
which contain JSON, we may simplify our API to allow
for a simple copy. Database backends will need to encode
the JSON prior to storing.